### PR TITLE
Change registry base URL

### DIFF
--- a/src/services/registry.ts
+++ b/src/services/registry.ts
@@ -1,7 +1,8 @@
 import { DenoDatabase } from "@/types";
 
 export const fetchRegistry = async (registry: string = "all") => {
-  const resp = await fetch(`https://registry.denoland.id/${registry}.json`);
+  const baseUrl = "https://registry.denoland-id.now.sh";
+  const resp = await fetch(`${baseUrl}/${registry}.json`);
   const data = (await resp.json()) as DenoDatabase;
   delete data.$schema;
   return data;


### PR DESCRIPTION
This PR fixes an unknown error on Vercel's side where `fetch` cannot connect to <https://registry.denoland.id>. The fix is by changing the base URL to <https://registry.denoland-id.now.sh>.